### PR TITLE
Clarify Google Analytics tracking ID format

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,8 +49,8 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-# Uncomment and insert your GA tracking ID to enable.
-id = "UA-11111111-1"
+# Comment out the next line to disable GA tracking.
+id = "UA-00000000-0"
 
 # Language configuration
 

--- a/config.toml
+++ b/config.toml
@@ -50,7 +50,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Uncomment and insert your GA tracking ID to enable.
-# id = "INSERT ID"
+id = "UA-11111111-1"
 
 # Language configuration
 


### PR DESCRIPTION
Specifying the format helps users figure out which ID they need. Also, enabling this by default because it'll be used by the "was this page helpful?" widget.