### PR TITLE
Changing placekitten links to be https

### DIFF
--- a/content/en/blog/news/second-post.md
+++ b/content/en/blog/news/second-post.md
@@ -189,11 +189,11 @@ Inline code inside table cells should still be distinguishable.
 
 Small images should be shown at their actual size.
 
-![](http://placekitten.com/g/300/200/)
+![](https://placekitten.com/g/300/200/)
 
 Large images should always scale down and fit in the content container.
 
-![](http://placekitten.com/g/1200/800/)
+![](https://placekitten.com/g/1200/800/)
 
 ## Components
 

--- a/content/en/blog/releases/in-depth-monoliths-detailed-spec.md
+++ b/content/en/blog/releases/in-depth-monoliths-detailed-spec.md
@@ -189,11 +189,11 @@ Inline code inside table cells should still be distinguishable.
 
 Small images should be shown at their actual size.
 
-![](http://placekitten.com/g/300/200/)
+![](https://placekitten.com/g/300/200/)
 
 Large images should always scale down and fit in the content container.
 
-![](http://placekitten.com/g/1200/800/)
+![](https://placekitten.com/g/1200/800/)
 
 ## Components
 


### PR DESCRIPTION
Changing these placekitten links to https so Netlify doesn't give mixed-content warnings (ahead of Docsy workshop next week at OSCON). SSL kittens for everyone! 😺