### PR TITLE
Add config option for about link in footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -102,7 +102,7 @@ sidebar_search_disable = false
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 # Set to true to disable the About link in the site footer
-footer_about_disable = true
+footer_about_disable = false
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.

--- a/config.toml
+++ b/config.toml
@@ -101,6 +101,8 @@ breadcrumb_disable = false
 sidebar_search_disable = false
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
+# Set to true to disable the About link in the site footer
+footer_about_disable = true
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.


### PR DESCRIPTION
I needed a way to disable the About link in the footer and discovered this option by looking in the code. It's working for my site using the Docsy theme so I thought other people might benefit from knowing about it.