### PR TITLE
Remove a unnecessary file

### DIFF
--- a/content/en/search-index.md
+++ b/content/en/search-index.md
@@ -1,4 +1,0 @@
----
-type: "search-index"
-url: "index.json"
----


### PR DESCRIPTION
The `content/en/search-index.md` is no longer needed for local search.