### PR TITLE
Update docsy theme & enable 'print entire section'

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,6 +78,10 @@ time_format_blog = "02.01.2006"
 
 # Everything below this are Site Params
 
+# Comment out if you don't want the "print entire section" link enabled.
+[outputs]
+section = ["HTML", "print"]
+
 [params]
 copyright = "The Docsy Authors"
 privacy_policy = "https://policies.google.com/privacy"


### PR DESCRIPTION
Turn on the "print entire section" feature that was pushed to Docsy.

Not sure how this is deployed, but might need to check it's using a relatively recent version of Hugo to deploy successfully.