### PR TITLE
Dockerfile + docker-compose.yaml build/running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM klakegg/hugo:0.78.2-asciidoctor
+
+RUN apk add git

--- a/README.md
+++ b/README.md
@@ -62,19 +62,25 @@ hugo server
 You can run docsy-example inside a [Docker](ihttps://docs.docker.com/)
 container, the container runs with a volume bound to the `docsy-example`
 folder. This approach doesn't require you to install any dependencies other
-than Docker.
+than Docker and Docker Compose.
+
+> Reference: https://docs.docker.com/compose/gettingstarted/
 
 1. Build the docker image 
 
 ```bash
-docker build -f dev.Dockerfile -t docsy-example-dev:latest .
+docker-compose build
 ```
 
 1. Run the built image
 
 ```bash
-docker run --publish 1313:1313 --detach --mount src="$(pwd)",target=/home/docsy/app,type=bind docsy-example-dev:latest
+docker-compose up
 ```
+
+> NOTE: You can run both commands at once as `docker-compose up --build` while you are working.
+
+1. Verify work 
 
 Open your web browser and type `http://localhost:1313` in your navigation bar,
 This opens a local instance of the docsy-example homepage. You can now make
@@ -84,18 +90,15 @@ browser after you save.
 To stop the container, first identify the container ID with:
 
 ```bash
-docker container ls
+CTRL + C to terminate `docker-compose` process
 ```
 
-Take note of the hexadecimal string below the `CONTAINER ID` column, then stop
-the container:
+That will terminate the container.
 
-```bash
-docker stop [container_id]
-```
+1. Remove produced images
 
-To delete the container run:
+You can execute `rm` to remove the produced images
 
-```
-docker container rm [container_id]
+```console
+docker-compose rm
 ```

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,8 +1,0 @@
-FROM klakegg/hugo:ext-nodejs
-WORKDIR /home/docsy/app
-RUN mkdir -p /home/docsy/deps
-COPY package.json /home/docsy/deps/
-COPY package-lock.json /home/docsy/deps/
-RUN cd /home/docsy/deps/ && npm install -g
-# COPY . .
-CMD [ "server" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
 
   site:
-    image: servicenow/github-pages-hugo
+    image: docsy/docsy-example
     build:
       context: .
     command: server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.3"
+
+services:
+
+  site:
+    image: servicenow/github-pages-hugo
+    build:
+      context: .
+    command: server
+    ports:
+      - "1313:1313"
+    volumes:
+      - .:/src


### PR DESCRIPTION
Add Dockerfile for building with the latest and the docker-compose, building the site and running. The current version of the `Dockerfile` does not work! It fails... the container stops because of an error... 

Instead of using the `Dockerfile`, we introduced a new Dockerfile with a different docker image with the latest version.

# Test logs for current version of Dockerfile - `broken`

* I think this is due to using an older version of `hugo`... 

```console
$ docker build -f dev.Dockerfile -t docsy-example-dev:latest .
...
...
 => => naming to docker.io/library/docsy-example-dev:latest                                                                                                                                                       0.0s

$ docker run --publish 1313:1313 --detach --mount src="$(pwd)",target=/home/docsy/app,type=bind docsy-example-dev:latest
675480225bab118b005b2ce4076949b83b401d57862a193db135900daa61ab8e

$ docker ps
CONTAINER ID        IMAGE                      COMMAND             CREATED             STATUS              PORTS                    NAMES
675480225bab        docsy-example-dev:latest   "hugo server"       2 seconds ago       Up 2 seconds        0.0.0.0:1313->1313/tcp   sweet_snyder

$ curl 0.0.0.0:1313
curl: (7) Failed to connect to 0.0.0.0 port 1313: Connection refused

$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES

$ docker start 675480225bab
675480225bab

$ docker logs 675480225bab
Building sites … ERROR 2020/12/17 08:10:25 render of "section" failed: execute of template failed: template: blog/section.print.html:2:3: executing "main" at <partial "print/render" .>: error calling partial: execute of template failed: template: partials/print/render.html:10:4: executing "recurse-toc" at <partial "print/toc-li.html" (dict "sid" $sid "Page" .)>: error calling partial: "/home/docsy/app/themes/docsy/layouts/partials/print/toc-li.html:3:5": execute of template failed: template: partials/print/toc-li.html:3:5: executing "partials/print/toc-li.html" at <partial $tpl .>: error calling partial: partial "/print/toc-li-blog.html" not found
ERROR 2020/12/17 08:10:25 failed to render pages: render of "section" failed: execute of template failed: template: blog/section.print.html:2:3: executing "main" at <partial "print/render" .>: error calling partial: execute of template failed: template: partials/print/render.html:10:4: executing "recurse-toc" at <partial "print/toc-li.html" (dict "sid" $sid "Page" .)>: error calling partial: "/home/docsy/app/themes/docsy/layouts/partials/print/toc-li.html:3:5": execute of template failed: template: partials/print/toc-li.html:3:5: executing "partials/print/toc-li.html" at <partial $tpl .>: error calling partial: partial "/print/toc-li-blog.html" not found
Error: Error building site: TOCSS: failed to transform "scss/main.scss" (text/x-scss): SCSS processing failed: file "stdin", line 6, col 1: File to import not found or unreadable: ../vendor/bootstrap/scss/bootstrap.
Built in 3321 ms
Building sites … ERROR 2020/12/17 08:11:27 render of "section" failed: execute of template failed: template: blog/section.print.html:2:3: executing "main" at <partial "print/render" .>: error calling partial: execute of template failed: template: partials/print/render.html:10:4: executing "recurse-toc" at <partial "print/toc-li.html" (dict "sid" $sid "Page" .)>: error calling partial: "/home/docsy/app/themes/docsy/layouts/partials/print/toc-li.html:3:5": execute of template failed: template: partials/print/toc-li.html:3:5: executing "partials/print/toc-li.html" at <partial $tpl .>: error calling partial: partial "/print/toc-li-blog.html" not found
ERROR 2020/12/17 08:11:27 failed to render pages: render of "section" failed: execute of template failed: template: blog/section.print.html:2:3: executing "main" at <partial "print/render" .>: error calling partial: execute of template failed: template: partials/print/render.html:10:4: executing "recurse-toc" at <partial "print/toc-li.html" (dict "sid" $sid "Page" .)>: error calling partial: "/home/docsy/app/themes/docsy/layouts/partials/print/toc-li.html:3:5": execute of template failed: template: partials/print/toc-li.html:3:5: executing "partials/print/toc-li.html" at <partial $tpl .>: error calling partial: partial "/print/toc-li-blog.html" not found
Built in 764 ms
Error: Error building site: TOCSS: failed to transform "scss/main.scss" (text/x-scss): SCSS processing failed: file "stdin", line 6, col 1: File to import not found or unreadable: ../vendor/bootstrap/scss/bootstrap.
```

# Build and start from `docker-compose`

* Just using `docker-compose` simplifies the development process...

```console
$ docker-compose up --build
Starting docsy-example_site_1 ... done
Attaching to docsy-example_site_1
site_1  | Start building sites …
site_1  |
site_1  |                    | FA | NO | EN
site_1  | -------------------+----+----+-----
site_1  |   Pages            | 18 | 76 | 46
site_1  |   Paginator pages  |  0 |  0 |  0
site_1  |   Non-page files   |  3 |  1 |  3
site_1  |   Static files     | 38 | 38 | 38
site_1  |   Processed images |  8 |  2 |  7
site_1  |   Aliases          |  3 |  0 |  3
site_1  |   Sitemaps         |  2 |  1 |  1
site_1  |   Cleaned          |  0 |  0 |  0
site_1  |
site_1  | Built in 837 ms
site_1  | Watching for changes in /src/{assets,content,layouts,package.json,themes}
site_1  | Watching for config changes in /src/config.toml, /src/themes/docsy/config.toml
site_1  | Environment: "DEV"
site_1  | Serving pages from memory
site_1  | Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
site_1  | Web Server is available at //localhost:1313/ (bind address 0.0.0.0)
site_1  | Press Ctrl+C to stop
```

* Optionally, you can just use `docker-compose up -d` to detach the process from the terminal.

# Open a new terminal and test it

```console
$ curl -X HEAD -i localhost:1313
Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
Warning: way you want. Consider using -I/--head instead.
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 27590
Content-Type: text/html; charset=utf-8
Last-Modified: Thu, 17 Dec 2020 08:47:13 GMT
Date: Thu, 17 Dec 2020 08:47:25 GMT
```