### PR TITLE
config.toml: comment typo: s/lang/length

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ category = "categories"
 # set taxonomyCloud = [] to hide taxonomy clouds
 taxonomyCloud = ["tags", "categories"] 
 
-# If used, must have same length as params.taxonomy.taxonomyCloud
+# If used, must have same length as taxonomyCloud
 taxonomyCloudTitle = ["Tag Cloud", "Categories"] 
 
 # set taxonomyPageHeader = [] to hide taxonomies on the page headers

--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ category = "categories"
 # set taxonomyCloud = [] to hide taxonomy clouds
 taxonomyCloud = ["tags", "categories"] 
 
-# If used, must have same lang as taxonomyCloud
+# If used, must have same length as params.taxonomy.taxonomyCloud
 taxonomyCloudTitle = ["Tag Cloud", "Categories"] 
 
 # set taxonomyPageHeader = [] to hide taxonomies on the page headers


### PR DESCRIPTION
I don't think taxonomyCloud has a language, and I think they need to have the same length, so I think this is what was intended.