### PR TITLE
Make docsy example site use docsy theme as hugo module

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,9 +10,6 @@ enableMissingTranslationPlaceholders = true
 
 enableRobotsTXT = true
 
-# Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
-
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 
@@ -220,3 +217,18 @@ enable = false
   url = "https://example.org/mail"
   icon = "fa fa-envelope"
   desc = "Discuss development issues around the project"
+
+# hugo module configuration
+
+[module]
+  # uncomment line below for temporary local development of module
+  # replacements = "github.com/google/docsy -> ../../docsy"
+  [module.hugoVersion]
+    extended = true
+    min = "0.75.0"
+  [[module.imports]]
+    path = "github.com/google/docsy"
+    disable = false
+  [[module.imports]]
+    path = "github.com/google/docsy/dependencies"
+    disable = false    

--- a/config.toml
+++ b/config.toml
@@ -137,9 +137,9 @@ github_project_repo = "https://github.com/google/docsy"
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""
 
-# Uncomment this if you have a newer GitHub repo with "main" as the default branch,
+# Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links
-# github_branch= "main"
+github_branch= "master"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "d72aa9b2712488cc3"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/google/docsy-example
+
+go 1.13
+
+require (
+	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
+	github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 // indirect
+	github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 // indirect
+	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 h1:+vc8wn8oOlLhjUOTvP6ljXuIi03HZWb9jWc4ZhVrO9g=
+github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
+github.com/google/docsy/dependencies v0.2.0-pre/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 h1:EKYx2OlWxo2HBhZ+dWzZbufBfh+qMKmz2K1lf1GJmto=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
+github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.94.0"
+HUGO_VERSION = "0.96.0"
+GO_VERSION = "1.18"


### PR DESCRIPTION
This PR is closely associated [PR 801](https://github.com/google/docsy/pull/801#issue-1076871740), which tries to bring hugo modules to docsy theme.
The goal is to make use of the example site as easy as possible:

```
git clone https://github.com/google/docsy-example
cd docsy-example
hugo server
```
No fiddling around with gut submodules any more.

Please note that this PR is not fully ready for review yet, inside my go.mod, I'm missing the commit hash of the docsy repo once [PR 801](https://github.com/google/docsy/pull/801#issue-1076871740) is applied. Or I can refer to commit in the branch `modules` (to be newly created in the Docsy repo).

