### PR TITLE
config.toml: change order of  language settings and theme/module declaration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,13 @@
 baseURL = "/"
 title = "Goldydocs"
 
+# Language settings
+contentDir = "content/en"
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = false
+# Useful when translating.
+enableMissingTranslationPlaceholders = true
+
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
@@ -8,13 +15,6 @@ theme = ["docsy"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true
-
-# Language settings
-contentDir = "content/en"
-defaultContentLanguage = "en"
-defaultContentLanguageInSubdir = false
-# Useful when translating.
-enableMissingTranslationPlaceholders = true
 
 # Comment out to enable taxonomies in Docsy
 # disableKinds = ["taxonomy", "taxonomyTerm"]


### PR DESCRIPTION


When using docsy as hugo module, inside `config.toml`, the language settings must declared prior to the `[module]` section. If you do not obey this load order, you are running in trouble.
This PR moves the language settings inside `config.toml` up to the top of the file. By doing so, we are ensuring a smooth transition for users that want to pull the docsy theme into the example site as a hugo module.
