### PR TITLE
docsy as module: refer to current HEAD of repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
-	github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 // indirect
-	github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 // indirect
+	github.com/google/docsy v0.2.0-pre.0.20220404161753-f7b37a0aca2a // indirect
+	github.com/google/docsy/dependencies v0.2.0-pre.0.20220404161753-f7b37a0aca2a // indirect
 	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,8 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4 h1:+vc8wn8oOlLhjUOTvP6ljXuIi03HZWb9jWc4ZhVrO9g=
-github.com/google/docsy v0.1.1-0.20220321183617-02df04c0f2d4/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
-github.com/google/docsy/dependencies v0.2.0-pre/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
-github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4 h1:EKYx2OlWxo2HBhZ+dWzZbufBfh+qMKmz2K1lf1GJmto=
-github.com/google/docsy/dependencies v0.2.0-pre.0.20220321183617-02df04c0f2d4/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/google/docsy v0.2.0-pre.0.20220404161753-f7b37a0aca2a h1:bnufXLbTD8QCLbqygy/kmYxUK1JINSlHU5rLQYTcFMQ=
+github.com/google/docsy v0.2.0-pre.0.20220404161753-f7b37a0aca2a/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220404161753-f7b37a0aca2a h1:fy6IqUmWGMdQngRa7+CP1cRkTseQK7OEsqx6r7dNuSA=
+github.com/google/docsy/dependencies v0.2.0-pre.0.20220404161753-f7b37a0aca2a/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
 github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
 github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR closes #167. 