### PR TITLE
Update example site to docsy theme v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/google/docsy-example
 
-go 1.13
+go 1.12
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
-	github.com/google/docsy v0.2.0-pre.0.20220404161753-f7b37a0aca2a // indirect
-	github.com/google/docsy/dependencies v0.2.0-pre.0.20220404161753-f7b37a0aca2a // indirect
+	github.com/google/docsy v0.2.0 // indirect
 	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
 )


### PR DESCRIPTION
This PR brings the example site to version `v0.2.0` of the docsy theme, to be released soon. This PR should be merged immediately before or after `v0.2.0` was released.