### PR TITLE
config.toml: remove section [blackfriday] (unsupported)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,13 +45,6 @@ pygmentsStyle = "tango"
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"
 
-## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
-[blackfriday]
-plainIDAnchors = true
-hrefTargetBlank = true
-angledQuotes = false
-latexDashes = true
-
 # Image processing configuration.
 [imaging]
 resampleFilter = "CatmullRom"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.96.0"
-GO_VERSION = "1.18"
+HUGO_VERSION = "0.100.1"
+GO_VERSION = "1.18.3"


### PR DESCRIPTION
As of version 0.100, hugo [dropped support](https://github.com/gohugoio/hugo/issues/9944) for Blackfriday markdown engine.
This PR makes changes to `config.toml` to reflect this.