### PR TITLE
Update docsy theme to docsy v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ github.com/google/docsy-example github.com/google/docsy/dependencies@v0.6.0
 github.com/google/docsy/dependencies@v0.6.0
 github.com/twbs/bootstrap@v4.6.2+incompatible
 github.com/google/docsy/dependencies@v0.6.0
-github.com/FortAwesome/Font-Awesome@v0.0.0-20220831210243-d3a7818c253f
+github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4
 ```
 
 You can find detailed theme instructions in the [Docsy user guide][].

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ In this project, the Docsy theme component is pulled in as a Hugo module, togeth
 $ hugo mod graph
 hugo: collected modules in 566 ms
 hugo: collected modules in 578 ms
-github.com/google/docsy-example github.com/google/docsy@v0.5.1-0.20221017155306-99eacb09ffb0
-github.com/google/docsy-example github.com/google/docsy/dependencies@v0.5.1-0.20221014161617-be5da07ecff1
-github.com/google/docsy/dependencies@v0.5.1-0.20221014161617-be5da07ecff1 github.com/twbs/bootstrap@v4.6.2+incompatible
-github.com/google/docsy/dependencies@v0.5.1-0.20221014161617-be5da07ecff1 github.com/FortAwesome/Font-Awesome@v0.0.0-20220831210243-d3a7818c253f
+github.com/google/docsy-example github.com/google/docsy@v0.6.0
+github.com/google/docsy-example github.com/google/docsy/dependencies@v0.6.0
+github.com/google/docsy/dependencies@v0.6.0
+github.com/twbs/bootstrap@v4.6.2+incompatible
+github.com/google/docsy/dependencies@v0.6.0
+github.com/FortAwesome/Font-Awesome@v0.0.0-20220831210243-d3a7818c253f
 ```
 
 You can find detailed theme instructions in the [Docsy user guide][].

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f // indirect
-	github.com/google/docsy v0.5.1 // indirect
+	github.com/google/docsy v0.6.0 // indirect
 	github.com/twbs/bootstrap v4.6.2+incompatible // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/google/docsy-example
 go 1.12
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 // indirect
 	github.com/google/docsy v0.6.0 // indirect
 	github.com/twbs/bootstrap v4.6.2+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,9 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f h1:bvkUpt
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.5.1 h1:D/ZdFKiE29xM/gwPwQzmkyXhcbQGkReRS6aGrF7lnYk=
 github.com/google/docsy v0.5.1/go.mod h1:maoUAQU5H/d+FrZIB4xg1EVWAx7RyFMGSDJyWghm31E=
+github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
+github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
 github.com/google/docsy/dependencies v0.5.1/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/twbs/bootstrap v4.6.2+incompatible h1:TDa+R51BTiy1wEHSYjmqDb8LxNl/zaEjAOpRE9Hwh/o=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f h1:bvkUptSRPZBr3Kxuk+bnWCEmQ5MtEJX5fjezyV0bC3g=
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 h1:xfr9SidRCMEh4A8fdkLhFPcHAVbrdv3Ua0Jp/nSmhhQ=
+github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.5.1 h1:D/ZdFKiE29xM/gwPwQzmkyXhcbQGkReRS6aGrF7lnYk=
 github.com/google/docsy v0.5.1/go.mod h1:maoUAQU5H/d+FrZIB4xg1EVWAx7RyFMGSDJyWghm31E=
 github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.104.3"
-GO_VERSION = "1.19.2"
+HUGO_VERSION = "0.107.0"
+GO_VERSION = "1.19.3"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.107.0"
-GO_VERSION = "1.19.3"
+HUGO_VERSION = "0.110.0"
+GO_VERSION = "1.20"


### PR DESCRIPTION
Update the theme, the README file, and the hugo and go versions.