### PR TITLE
Change the default baseURL as example.org

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://example.docsy.dev/"
 title = "Goldydocs"
 
 # Language settings


### PR DESCRIPTION
A minor change that allow clicking the URL from console.

```sh
hugo server
...
Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
```

With this PR:

```sh
hugo server
...
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
```