### PR TITLE
Fix: remove warnings emitted from hugo v0.112

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,23 +61,27 @@ id = "UA-00000000-0"
 [languages]
 [languages.en]
 title = "Goldydocs"
-description = "A Docsy example site"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+[languages.en.params]
+description = "A Docsy example site"
+
 [languages.no]
 title = "Goldydocs"
-description = "Docsy er operativsystem for skyen"
 languageName ="Norsk"
 contentDir = "content/no"
+[languages.no.params]
+description = "Docsy er operativsystem for skyen"
 time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 
 [languages.fa]
 title = "اسناد گلدی"
-description = "یک نمونه برای پوسته داکسی"
 languageName ="فارسی"
 contentDir = "content/fa"
+[languages.fa.params]
+description = "یک نمونه برای پوسته داکسی"
 time_format_default = "2006.01.02"
 time_format_blog = "2006.01.02"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.104.3"
-GO_VERSION = "1.19.2"
+HUGO_VERSION = "0.112.1"
+GO_VERSION = "1.20.4"


### PR DESCRIPTION
When running the example site with hugo v0.112, a bunch of warnings is emitted:

```
WARN 2023/05/23 22:02:22 config: languages.no.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.no.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN 2023/05/23 22:02:22 config: languages.no.time_format_default: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.no.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN 2023/05/23 22:02:22 config: languages.no.time_format_blog: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.no.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN 2023/05/23 22:02:22 config: languages.fa.time_format_default: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.fa.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN 2023/05/23 22:02:22 config: languages.fa.time_format_blog: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.fa.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN 2023/05/23 22:02:22 config: languages.fa.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.fa.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN 2023/05/23 22:02:22 config: languages.en.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```
This PR eliminates these warnings.