### PR TITLE
Set version to 0.7.0-dev, adjust default branch, and more

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,13 +23,13 @@ category = "categories"
 
 [params.taxonomy]
 # set taxonomyCloud = [] to hide taxonomy clouds
-taxonomyCloud = ["tags", "categories"] 
+taxonomyCloud = ["tags", "categories"]
 
 # If used, must have same length as taxonomyCloud
-taxonomyCloudTitle = ["Tag Cloud", "Categories"] 
+taxonomyCloudTitle = ["Tag Cloud", "Categories"]
 
 # set taxonomyPageHeader = [] to hide taxonomies on the page headers
-taxonomyPageHeader = ["tags", "categories"] 
+taxonomyPageHeader = ["tags", "categories"]
 
 
 # Highlighting config
@@ -60,27 +60,27 @@ id = "UA-00000000-0"
 
 [languages]
 [languages.en]
-title = "Goldydocs"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
 [languages.en.params]
+title = "Goldydocs"
 description = "A Docsy example site"
 
 [languages.no]
-title = "Goldydocs"
 languageName ="Norsk"
 contentDir = "content/no"
 [languages.no.params]
+title = "Goldydocs"
 description = "Docsy er operativsystem for skyen"
 time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 
 [languages.fa]
-title = "اسناد گلدی"
 languageName ="فارسی"
 contentDir = "content/fa"
 [languages.fa.params]
+title = "اسناد گلدی"
 description = "یک نمونه برای پوسته داکسی"
 time_format_default = "2006.01.02"
 time_format_blog = "2006.01.02"
@@ -112,13 +112,13 @@ privacy_policy = "https://policies.google.com/privacy"
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
 
-# Flag used in the "version-banner" partial to decide whether to display a 
+# Flag used in the "version-banner" partial to decide whether to display a
 # banner on every page indicating that this is an archived version of the docs.
 # Set this flag to "true" if you want to display the banner.
 archived_version = false
 
 # The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the 
+# Used in the "version-banner" partial to display a version number for the
 # current doc set.
 version = "0.0"
 
@@ -136,7 +136,7 @@ github_project_repo = "https://github.com/google/docsy"
 
 # Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links
-github_branch= "master"
+github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "d72aa9b2712488cc3"
@@ -176,7 +176,7 @@ yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/i
 no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
-# If you want this feature, but occasionally need to remove the Reading time from a single page, 
+# If you want this feature, but occasionally need to remove the Reading time from a single page,
 # add "hide_readingtime: true" to the page's front matter
 [params.ui.readingtime]
 enable = false
@@ -222,10 +222,10 @@ enable = false
   # replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
-    min = "0.75.0"
+    min = "0.110.0"
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false
   [[module.imports]]
     path = "github.com/google/docsy/dependencies"
-    disable = false    
+    disable = false

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,3 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.112.1"
 GO_VERSION = "1.20.4"

--- a/package.json
+++ b/package.json
@@ -1,24 +1,21 @@
 {
   "name": "docsy-example-site",
-  "version": "0.6.0",
-  "description": "Example site that uses docsy theme for technical documentation.",
-  "main": "none.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/google/docsy-example.git"
-  },
-  "author": "",
+  "version": "0.7.0-dev.0-unreleased",
+  "description": "Example site that uses Docsy theme for technical documentation.",
+  "repository": "github:google/docsy-example",
+  "homepage": "https://example.docsy.dev",
+  "author": "Docsy Authors",
   "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/google/docsy-example/issues"
+  "bugs": "https://github.com/google/docsy-example/issues",
+  "scripts": {
+    "_serve:hugo": "hugo server -DFE --minify",
+    "build": "hugo --cleanDestinationDir -e dev -DFE",
+    "serve": "npm run _serve:hugo",
+    "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest"
   },
-  "homepage": "https://github.com/google/docsy-example#readme",
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "postcss": "^8.3.7",
+    "hugo-extended": "0.113.0",
     "postcss-cli": "^10.1.0"
   }
 }


### PR DESCRIPTION
- Contributes to #207
- Upgrades to latest Hugo
- Renames default branch to `main` in config file
- Moves `title` under `languages.<lang>.params` so that `og:site_name` gets generated
- Best reviewed by ignoring whitespace changes