### PR TITLE
Netlify config: drop NPM prepare command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,10 +2,11 @@
 # (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
 
 [build]
-command = "npm build:preview"
+command = "npm run build:preview"
+publish = "public"
 
 [build.environment]
 GO_VERSION = "1.20.4"
 
 [context.production]
-command = "npm build:production"
+command = "npm run build:production"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "precheck:links": "npm run build",
     "postbuild:preview": "npm run _check:links",
     "postbuild:production": "npm run _check:links",
-    "prepare": "cd .. && npm install",
     "serve": "npm run _serve",
     "test": "npm run check:links",
     "update:pkg:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",


### PR DESCRIPTION
- Contributes to #207
- Drop NPM `prepare` command since this site is build using Hugo modules

We now have easily accessible build previews!

> <img width="842" alt="image" src="https://github.com/google/docsy-example/assets/4140793/a5803131-663e-4526-a865-d152019ac0e6">
