### PR TITLE
Drop themesDir from NPM script, tweak README, add dict

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "Docsy",
+    "Goldydocs"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can clone/copy this project and edit it with your own content, or use it as 
 
 In this project, the Docsy theme component is pulled in as a Hugo module, together with other module dependencies:
 
-```bash
+```console
 $ hugo mod graph
 hugo: collected modules in 566 ms
 hugo: collected modules in 578 ms
@@ -28,7 +28,7 @@ This is not an officially supported Google product. This project is currently ma
 
 ## Using the Docsy Example Project as a template
 
-A simple way to get started is to use this project as a template, which gives you a site project that is set up and ready to use. To do this: 
+A simple way to get started is to use this project as a template, which gives you a site project that is set up and ready to use. To do this:
 
 1. Click **Use this template**.
 
@@ -56,7 +56,7 @@ You can find out more about how to install Hugo for your environment in our
 
 Once you've made your working copy of the site repo, from the repo root folder, run:
 
-```
+```bash
 hugo server
 ```
 
@@ -69,7 +69,7 @@ than [Docker Desktop](https://www.docker.com/products/docker-desktop) on
 Windows and Mac, and [Docker Compose](https://docs.docker.com/compose/install/)
 on Linux.
 
-1. Build the docker image 
+1. Build the docker image
 
    ```bash
    docker-compose build
@@ -83,7 +83,7 @@ on Linux.
 
    > NOTE: You can run both commands at once with `docker-compose up --build`.
 
-1. Verify that the service is working. 
+1. Verify that the service is working.
 
    Open your web browser and type `http://localhost:1313` in your navigation bar,
    This opens a local instance of the docsy-example homepage. You can now make
@@ -92,11 +92,11 @@ on Linux.
 
 ### Cleanup
 
-To stop Docker Compose, on your terminal window, press **Ctrl + C**. 
+To stop Docker Compose, on your terminal window, press **Ctrl + C**.
 
 To remove the produced images run:
 
-```console
+```bash
 docker-compose rm
 ```
 For more information see the [Docker Compose
@@ -106,10 +106,10 @@ documentation](https://docs.docker.com/compose/gettingstarted/).
 
 As you run the website locally, you may run into the following error:
 
-```
-➜ hugo server
+```console
+$ hugo server
 
-INFO 2021/01/21 21:07:55 Using config file: 
+INFO 2021/01/21 21:07:55 Using config file:
 Building sites … INFO 2021/01/21 21:07:55 syncing static files to /
 Built in 288 ms
 Error: Error building site: TOCSS: failed to transform "scss/main.scss" (text/x-scss): resource "scss/scss/main.scss_9fadf33d895a46083cdd64396b57ef68" not found in file cache
@@ -120,8 +120,8 @@ See this [section](https://www.docsy.dev/docs/get-started/docsy-as-module/instal
 
 Or you may encounter the following error:
 
-```
-➜ hugo server
+```console
+$ hugo server
 
 Error: failed to download modules: binary with name "go" not found
 ```

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "author": "Docsy Authors",
   "license": "Apache-2.0",
   "bugs": "https://github.com/google/docsy-example/issues",
+  "spelling": "cSpell:ignore HTMLTEST precheck postbuild -",
   "scripts": {
     "_build": "npm run _hugo-dev",
     "_check:links": "echo IMPLEMENTATION PENDING for check-links; echo",
-    "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
+    "_hugo": "hugo --cleanDestinationDir",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_serve": "npm run _hugo-dev -- --minify serve",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",


### PR DESCRIPTION
- Contributes to #216
- Drops `--themesDir` from `_hugo` script
- Tweaks readme, mainly fixing code-block language
- Adds a cSpell dictionary under VSCode settings