### PR TITLE
Drop placeholder _variables_project.scss

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1,6 +1,0 @@
-/*
-
-Add styles or override variables from the theme here.
-
-*/
-


### PR DESCRIPTION
This placeholder file mimics the Docsy one. Let's just drop it. (If we need to mention something about the custom project files, we should instead direct users to https://www.docsy.dev/docs/adding-content/lookandfeel/#project-style-files.