### PR TITLE
Add a error-detection config for older versions of Hugo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,14 @@
+# HUGO-VERSION TEST CONFIG ONLY
+#
+# As of Docsy 0.7.0, Hugo 0.110.0 or later must be used.
+#
+# The sole purpose of this config file is to detect Hugo-module builds that use
+# an older version of Hugo.
+#
+# DO NOT add any config parameters to this file. You can safely delete this file
+# if your project is using the required Hugo version.
+
+module:
+  hugoVersion:
+    extended: true
+    min: 0.110.0

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
-# HUGO-VERSION TEST CONFIG ONLY
+# THIS IS A TEST CONFIG ONLY!
+# FOR THE CONFIGURATION OF YOUR SITE USE hugo.yaml.
 #
 # As of Docsy 0.7.0, Hugo 0.110.0 or later must be used.
 #


### PR DESCRIPTION
- Closes #228
- E.g., when using Hugo 0.109:
  ```console
  $ npx hugo
  WARN 2023/06/26 16:59:04 Module "project" is not compatible with this Hugo version; run "hugo mod graph" for more information.
  Start building sites … 
  hugo v0.109.0-47b12b83e636224e5e601813ff3e6790c191e371+extended darwin/amd64 BuildDate=2022-12-23T10:38:11Z VendorInfo=gohugoio
  Error: Error building site: "/Users/chalin/git/lf/docsy/docsy-example/content/en/_index.md:5:1": failed to extract shortcode: template for shortcode "blocks/cover" not found
  Total in 21 ms
  ```
- Adding this config file does not (seem to) affect builds using Hugo 0.110.0 and later (as we can see from the build of this PR).

/cc @geriom 