### PR TITLE
Update example site to latest docsy development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ In this project, the Docsy theme component is pulled in as a Hugo module, togeth
 
 ```console
 $ hugo mod graph
-hugo: collected modules in 566 ms
-hugo: collected modules in 578 ms
-github.com/google/docsy-example github.com/google/docsy@v0.7.2
-github.com/google/docsy-example github.com/google/docsy/dependencies@v0.7.2
-github.com/google/docsy/dependencies@v0.7.2 github.com/twbs/bootstrap@v5.2.3+incompatible
-github.com/google/docsy/dependencies@v0.7.2 github.com/FortAwesome/Font-Awesome@v0.0.0-20230327165841-0698449d50f2
+hugo: collected modules in 520 ms
+ithub.com/google/docsy-example github.com/google/docsy@v0.7.3-0.20231112231447-8e9cb3c722ca
+github.com/google/docsy@v0.7.3-0.20231112231447-8e9cb3c722ca github.com/twbs/bootstrap@v5.2.3+incompatible
+github.com/google/docsy@v0.7.3-0.20231112231447-8e9cb3c722ca github.com/FortAwesome/Font-Awesome@v0.0.0-20230327165841-0698449d50f2
 ```
 
 You can find detailed theme instructions in the [Docsy user guide][].

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 // indirect
-	github.com/google/docsy v0.7.2 // indirect
-	github.com/google/docsy/dependencies v0.7.2 // indirect
-	github.com/twbs/bootstrap v5.2.3+incompatible // indirect
-)
+require github.com/google/docsy v0.7.3-0.20231112231447-8e9cb3c722ca // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 h1:Uv1z5EqCfmiK4IHUwT0m3h/u/WCk+kpRfxvAZhpC7Gc=
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.7.2 h1:KzhFgTd3taF1jq9HDemH3omlUqn9qfdE68sxRyTySpM=
-github.com/google/docsy v0.7.2/go.mod h1:ol3w2s1FBUzENdKSAEeNjtuaISUzHYHTw60xv5QH3Dg=
-github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
-github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/google/docsy v0.7.3-0.20231112231447-8e9cb3c722ca h1:DUdXsNcTk8jCv6sOa/HtM9/z1tFb0KGabREkH7xuIzg=
+github.com/google/docsy v0.7.3-0.20231112231447-8e9cb3c722ca/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -225,6 +225,3 @@ enable = false
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false
-  [[module.imports]]
-    path = "github.com/google/docsy/dependencies"
-    disable = false


### PR DESCRIPTION
This PR update the example site to the latest docsy development version `v0.7.3-dev`.