### PR TITLE
Upgrade Docsy to 0.7.3-dev 2023-11-14 revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.7.3-0.20231112231447-8e9cb3c722ca // indirect
+require github.com/google/docsy v0.7.3-0.20231114182345-885fad8d3625 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 h1:Uv1z5EqCfmiK4IHUwT0m3h/u/WCk+kpRfxvAZhpC7Gc=
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.7.3-0.20231112231447-8e9cb3c722ca h1:DUdXsNcTk8jCv6sOa/HtM9/z1tFb0KGabREkH7xuIzg=
-github.com/google/docsy v0.7.3-0.20231112231447-8e9cb3c722ca/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
+github.com/google/docsy v0.7.3-0.20231114182345-885fad8d3625 h1:XZK8jPI1Cz4BKKc9HgQnJXL3USQR1QF91Ewd+DA90T8=
+github.com/google/docsy v0.7.3-0.20231114182345-885fad8d3625/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -51,11 +51,6 @@ resampleFilter = "CatmullRom"
 quality = 75
 anchor = "smart"
 
-[services]
-[services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
-
 # Language configuration
 
 [languages]
@@ -218,7 +213,7 @@ enable = false
 
 [module]
   # Uncomment the next line to build and serve using local docsy clone declared in the named Hugo workspace:
-  # workspace = "docsy.work" 
+  # workspace = "docsy.work"
   [module.hugoVersion]
     extended = true
     min = "0.110.0"


### PR DESCRIPTION
- Upgrades Docsy so that we can test new GA4 and page feedback features
- Contributes to prep for testing of https://github.com/google/docsy/issues/1302
