### PR TITLE
Docker files: change to another provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM klakegg/hugo:ext-alpine
+FROM floryn90/hugo:ext-alpine
 
 RUN apk add git && \
   git config --global --add safe.directory /src

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.8"
 
 services:
 


### PR DESCRIPTION
The docker container we refer to is not well maintained any more. This PR changes to another container that has latest hugo version `0.120.4`.