### PR TITLE
Upgrade Docsy to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@ site navigation, structure, and more. This **Docsy Example Project** uses the Do
 theme component as a hugo module and provides a skeleton documentation structure for you to use.
 You can clone/copy this project and edit it with your own content, or use it as an example.
 
-In this project, the Docsy theme component is pulled in as a Hugo module, together with other module dependencies:
+In this project, the Docsy theme is pulled in as a Hugo module, together with
+its dependencies:
 
 ```console
 $ hugo mod graph
-hugo: collected modules in 520 ms
-ithub.com/google/docsy-example github.com/google/docsy@v0.7.3-0.20231112231447-8e9cb3c722ca
-github.com/google/docsy@v0.7.3-0.20231112231447-8e9cb3c722ca github.com/twbs/bootstrap@v5.2.3+incompatible
-github.com/google/docsy@v0.7.3-0.20231112231447-8e9cb3c722ca github.com/FortAwesome/Font-Awesome@v0.0.0-20230327165841-0698449d50f2
+...
 ```
 
-You can find detailed theme instructions in the [Docsy user guide][].
+For Docsy documentation, see [Docsy user guide][].
 
 This Docsy Example Project is hosted on [Netlify][] at [example.docsy.dev][].
 You can view deploy logs from the [deploy section of the project's Netlify
@@ -27,7 +25,7 @@ This is not an officially supported Google product. This project is currently ma
 
 A simple way to get started is to use this project as a template, which gives you a site project that is set up and ready to use. To do this:
 
-1. Use the dropdown for switching branches/tags to change to the latest released tag `v0.7.2`
+1. Use the dropdown for switching branches/tags to change to the **latest** released tag.
 
 2. Click **Use this template**.
 
@@ -129,7 +127,7 @@ In the command above, we used the environment variable `HUGO_MODULE_WORKSPACE` t
 
 ```toml
 [module]
-  workspace = "docsy.work" 
+  workspace = "docsy.work"
 ```
 
 Your project's `hugo.toml` file already contains these lines, the directive for workspace assignment is commented out, however. Remove the two trailing comment characters '//' so that this line takes effect.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.7.3-0.20231114182345-885fad8d3625 // indirect
+require github.com/google/docsy v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 h1:Uv1z5EqCfmiK4IHUwT0m3h/u/WCk+kpRfxvAZhpC7Gc=
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.7.3-0.20231114182345-885fad8d3625 h1:XZK8jPI1Cz4BKKc9HgQnJXL3USQR1QF91Ewd+DA90T8=
-github.com/google/docsy v0.7.3-0.20231114182345-885fad8d3625/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
+github.com/google/docsy v0.8.0 h1:RgHyKRTo8YwScMThrf01Ky2yCGpUS1hpkspwNv6szT4=
+github.com/google/docsy v0.8.0/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "docsy-example-site",
-  "version": "0.7.3-dev.0-unreleased",
+  "version": "0.8.0",
+  "version.next": "0.8.1-dev.0-unreleased",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",


### PR DESCRIPTION
- We were already at a pre-release, so there are fewer changes than might be expected.
- https://github.com/google/docsy/releases/tag/v0.8.0
- https://github.com/google/docsy/issues/1667

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.1") | grep ^diff                       
diff --git a/scss/main.css.map b/scss/main.css.map
```
