### PR TITLE
Specify `fa` as `rtl` lang + NPM script tweak

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -70,6 +70,7 @@ time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 
 [languages.fa]
+languageDirection = "rtl"
 languageName ="فارسی"
 contentDir = "content/fa"
 title = "اسناد گلدی"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "_hugo": "hugo --cleanDestinationDir",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_local": "npx cross-env HUGO_MODULE_WORKSPACE=docsy.work",
-    "_serve": "npm run _hugo-dev -- --minify serve",
+    "_serve": "npm run _hugo-dev -- --minify serve --renderToMemory",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify",
     "build": "npm run _build -- ",


### PR DESCRIPTION
- Prep for #295
- Declares `fa` as an `rtl` language. Note that this has no effect on the generated files currently, since Docsy doesn't recognize RTL language (yet)
- Minor NPM script tweak