### PR TITLE
Upgrade Docsy to include RTL support + tweak `fa` config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.10.0 // indirect
+require github.com/google/docsy v0.10.1-0.20240516225026-36746913371a // indirect - v0.10.0-7-g3674691

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
 github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy v0.10.1-0.20240516225026-36746913371a h1:Fmx4SmmyWZf4q3rq9jhVWr6/h2MKEi4+61irjQO2ylI=
+github.com/google/docsy v0.10.1-0.20240516225026-36746913371a/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -60,11 +60,11 @@ languages:
       time_format_blog: 02.01.2006
   fa:
     languageDirection: rtl
-    languageName: فارسی
+    languageName: "فارسی (Persian)"
     contentDir: content/fa
-    title: اسناد گلدی
+    title: "اسناد گلدی"
     params:
-      description: یک نمونه برای پوسته داکسی
+      description: "یک نمونه برای پوسته داکسی"
       time_format_default: 2006.01.02
       time_format_blog: 2006.01.02
   # cSpell:enable


### PR DESCRIPTION
- Contributes to #295
- Upgrades Docsy to v0.10.0-7-g3674691, which includes RTL support
- Teaks the Persian config parameters.

**Preview**: https://deploy-preview-300--goldydocs.netlify.app/fa/

/cc @google/docsy-approvers