### PR TITLE
Upgrade Docsy to v0.10.0-12-g333c2f8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.10.1-0.20240528200232-6549143cf323 // indirect - v0.10.0-11-g6549143
+require github.com/google/docsy v0.10.1-0.20240529105443-333c2f8d4172 // indirect - v0.10.0-12-g333c2f8

--- a/go.sum
+++ b/go.sum
@@ -5,4 +5,6 @@ github.com/google/docsy v0.10.1-0.20240516225026-36746913371a h1:Fmx4SmmyWZf4q3r
 github.com/google/docsy v0.10.1-0.20240516225026-36746913371a/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy v0.10.1-0.20240528200232-6549143cf323 h1:T4UiGpcrIgiuyQj0tc7BtJwv6u736J8Jnl4QZno0fk4=
 github.com/google/docsy v0.10.1-0.20240528200232-6549143cf323/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy v0.10.1-0.20240529105443-333c2f8d4172 h1:1gAAuOfHRok/hJqfF+wpjOYqlH0d76dwUsskLEnOzxo=
+github.com/google/docsy v0.10.1-0.20240529105443-333c2f8d4172/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
- Contributes to #295
- **Preview**: https://deploy-preview-305--goldydocs.netlify.app/fa/

### Screenshot

This illustrates the fix to https://github.com/google/docsy/issues/2011:

> <img width="1009" alt="image" src="https://github.com/google/docsy-example/assets/4140793/e7fa60fa-9f44-4a7b-8659-b19bea8ba20d">
