### PR TITLE
Upgrade Docsy to v0.10.0-33-gfe0d785, add rtlcss pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.10.1-0.20240529105443-333c2f8d4172 // indirect - v0.10.0-12-g333c2f8
+require github.com/google/docsy v0.10.1-0.20241010163453-fe0d785d8f01 // indirect - v0.10.0-33-gfe0d785

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
 github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy v0.10.1-0.20240516225026-36746913371a h1:Fmx4SmmyWZf4q3rq9jhVWr6/h2MKEi4+61irjQO2ylI=
@@ -7,4 +8,6 @@ github.com/google/docsy v0.10.1-0.20240528200232-6549143cf323 h1:T4UiGpcrIgiuyQj
 github.com/google/docsy v0.10.1-0.20240528200232-6549143cf323/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy v0.10.1-0.20240529105443-333c2f8d4172 h1:1gAAuOfHRok/hJqfF+wpjOYqlH0d76dwUsskLEnOzxo=
 github.com/google/docsy v0.10.1-0.20240529105443-333c2f8d4172/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy v0.10.1-0.20241010163453-fe0d785d8f01 h1:PGGIH7Ht1jK6P+OADMs6LnKQd1gayU3Jqc+7jWlQIgg=
+github.com/google/docsy v0.10.1-0.20241010163453-fe0d785d8f01/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "autoprefixer": "^10.4.14",
     "cross-env": "^7.0.3",
     "hugo-extended": "0.135.0",
-    "postcss-cli": "^11.0.0"
+    "postcss-cli": "^11.0.0",
+    "rtlcss": "^4.3.0"
   },
   "private": true,
   "prettier": {


### PR DESCRIPTION
- Contributes to #295
- **Preview**: https://deploy-preview-322--goldydocs.netlify.app/fa/docs/

### Screenshot

Illustrates that the top-nav and footer are better than ever, in particular that the following have been fixed:

- https://github.com/google/docsy/issues/2005
- https://github.com/google/docsy/issues/2011

> <img width="1036" alt="image" src="https://github.com/user-attachments/assets/d1450a82-b1d4-4410-901c-ff604889c942">

Contrast this with the previous iteration, via #305:

- https://deploy-preview-305--goldydocs.netlify.app/fa/docs/