### PR TITLE
[i18n] Ensure that "Learn more" of non-en index links to same-language docs

### DIFF
--- a/content/fa/_index.md
+++ b/content/fa/_index.md
@@ -3,7 +3,7 @@ title: اسناد گلدی
 ---
 
 {{< blocks/cover title="به اسناد گلدی خوش آمدید. این یک نمونه برای پوسته داکسی می‌باشد." image_anchor="top" height="full" >}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="/docs/">
+<a class="btn btn-lg btn-primary me-3 mb-4" href="docs/">
     بیشتر بخوانید <i class="fas fa-arrow-alt-circle-left ms-2"></i>
 </a>
 <a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/google/docsy-example">

--- a/content/no/_index.html
+++ b/content/no/_index.html
@@ -3,11 +3,13 @@ title: TechOS
 ---
 
 {{< blocks/cover title="Dette er TechOS!" image_anchor="top" height="full" >}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="{{< relref "/docs" >}}">
+
+<a class="btn btn-lg btn-primary me-3 mb-4" href="docs/">
   Dokumentasjon <i class="fas fa-arrow-alt-circle-right ms-2"></i>
 </a>
 <a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/bep">
   Last ned <i class="fab fa-github ms-2 "></i>
 </a>
 <p class="lead mt-5">TechOS kan nå lastes ned i <a href="#">AppStore!</a></p>
+
 {{< /blocks/cover >}}


### PR DESCRIPTION
- Before this change the `fa` index page's "Learn more" button would link to the `en` docs page. This PR fixes that uniformly for `fa` and `no` pages, without the need to resort to the use of `relref`.
- Contributes to #295
- **Preview**: https://deploy-preview-325--goldydocs.netlify.app/fa/