### PR TITLE
Community page cleanup: move comment into front matter

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Community
 menu: {main: {weight: 40}}
+# Add blocks of content here to add more sections to the community page
 ---
-
-<!--add blocks of content here to add more sections to the community page -->


### PR DESCRIPTION
Otherwise, this can prevent the page description from being automatically set to a reasonable value -- because the page content isn't empty, but the content isn't meaningful.