### PR TITLE
Bump to latest docsy theme so that we eventually can use latest hugo version 0.146

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.11.0
+require github.com/google/docsy v0.11.1-0.20250424121410-343cdec14c0a

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
-github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
-github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.11.1-0.20250424121410-343cdec14c0a h1:yBtSn/NdYPZ2ScEyNbqCruLleEh+r6OS4kKCU2HYyEU=
+github.com/google/docsy v0.11.1-0.20250424121410-343cdec14c0a/go.mod h1:jafNHER7YZwS1P24oXqemNBfGLXbGmcXX0HTQIip/N4=
+github.com/twbs/bootstrap v5.3.5+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,1 @@
-{{ template "_default/_markup/td-render-heading.html" . }}
+{{ partial "td/render-heading.html" . }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docsy-example-site",
-  "version": "0.10.0",
-  "version.next": "0.10.1-dev.0-unreleased",
+  "version": "0.11.1-dev-unreleased",
+  "version.next": "0.12.0-dev-unreleased",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",
@@ -35,14 +35,14 @@
     "update:pkgs": "npx npm-check-updates -u"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.20",
+    "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "hugo-extended": "0.145.0",
-    "postcss-cli": "^11.0.0",
+    "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },
   "optionalDependencies": {
-    "npm-check-updates": "^18.0.0"
+    "npm-check-updates": "^18.0.1"
   },
   "private": true,
   "prettier": {


### PR DESCRIPTION
This PR Bump to latest docsy theme so that example site can use latest hugo version 0.146.

This PR closes #354.