### PR TITLE
Fix warning about deprecated kind 'taxonomyterm' in disableKinds

### DIFF
--- a/hugo-disabled.toml
+++ b/hugo-disabled.toml
@@ -13,8 +13,8 @@ enableRobotsTXT = true
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 
-# Comment out to enable taxonomies in Docsy
-# disableKinds = ["taxonomy", "taxonomyTerm"]
+# Comment out to disable taxonomies in Docsy
+# disableKinds = ["taxonomy"]
 
 # You can add your own taxonomies
 [taxonomies]

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -15,8 +15,8 @@ enableRobotsTXT: true
 # Will give values to .Lastmod etc.
 enableGitInfo: true
 
-# Comment out to enable taxonomies in Docsy
-# disableKinds: [taxonomy, taxonomyTerm]
+# Comment out to disable taxonomies in Docsy
+# disableKinds: [taxonomy]
 
 # You can add your own taxonomies
 taxonomies:


### PR DESCRIPTION
**Reproduction:**:

Comment out this line in `hugo.yaml`:

```
disableKinds = ["taxonomy", "taxonomyTerm"]
```

Now when previewing the site, a warning appears:

```
WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
```

This PR fixes that issue.
