### PR TITLE
Bump hugo-extended from 0.145.0 to 0.147.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
-    "hugo-extended": "0.145.0",
+    "hugo-extended": "0.147.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
This PR supersedes #353.