### PR TITLE
Update packages, Hugo to 0.150.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "cross-env": "^10.0.0",
-    "hugo-extended": "0.148.2",
+    "cross-env": "^10.1.0",
+    "hugo-extended": "0.150.1",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
- Closes #386 (which seems to be blocked), by superseding it.
- The bot upgrade PR was block/failing (as was this one originally), because of #388