### PR TITLE
Upgrade Hugo to 0.151.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.150.1",
+    "hugo-extended": "0.151.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
- Upgrades to Hugo 0.151.0
- Results in no changes to generated pages, other than the Hugo version