### PR TITLE
Fix deprecation warnings emitted from hugo 0.158.0

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -56,13 +56,13 @@ imaging:
 # Language configuration
 languages:
   en:
-    languageName: English
+    label: English
     title: Goldydocs
     params:
       description: A Docsy example site
   # cSpell:disable
   no:
-    languageName: Norsk
+    label: Norsk
     contentDir: content/no
     title: Gulldoks
     params:
@@ -70,8 +70,8 @@ languages:
       time_format_default: 02.01.2006
       time_format_blog: 02.01.2006
   fa:
-    languageDirection: rtl
-    languageName: 'فارسی (Persian)'
+    direction: rtl
+    label: 'فارسی (Persian)'
     contentDir: content/fa
     title: 'اسناد گلدی'
     params:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.157.0",
+    "hugo-extended": "0.161.1",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.161.1",
+    "hugo-extended": "0.158.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
When running the site with latest released hugo version 0.158.0, deprecation warnings are printed out:

```
INFO  deprecated: project config key languages.en.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.en.label instead.
INFO  deprecated: project config key languages.no.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.no.label instead.
INFO  deprecated: project config key languages.fa.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.fa.label instead.
INFO  deprecated: project config key languages.fa.languageDirection was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.fa.direction instead.
INFO  deprecated: project config key languages.no.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.no.label instead.
INFO  deprecated: project config key languages.fa.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.fa.label instead.
INFO  deprecated: project config key languages.fa.languageDirection was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.fa.direction instead.
INFO  deprecated: project config key languages.en.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.en.label instead.
```
See: https://discourse.gohugo.io/t/deprecations-in-v0-158-0/56869

This PR fixes these warnings.