### PR TITLE
Docsy 0.15.0-rc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy v0.14.3
+require github.com/google/docsy v0.14.4-0.20260501131222-9d97eedfc87c
 
 // cSpell:ignore github docsy

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.14.3 h1:4uFgPWTPj4NT79IboVkXGi49LLQadLVfU4WNOfD/s74=
-github.com/google/docsy v0.14.3/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
+github.com/google/docsy v0.14.4-0.20260501131222-9d97eedfc87c h1:lrRk6tzW4QGStDuuIpMGrayT/iH0J21oRvKWJTEcA3U=
+github.com/google/docsy v0.14.4-0.20260501131222-9d97eedfc87c/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -129,10 +129,10 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.14.4-dev
+  version: 0.15.0-rc
 
   # Internal version number with build ID.
-  versionWithBuildId: 0.14.4-dev
+  versionWithBuildId: 0.15.0-rc
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/google/docsy-example
@@ -250,7 +250,7 @@ module:
   # workspace: docsy.work
   hugoVersion:
     extended: true
-    min: 0.155.0
+    min: 0.157.0
   imports:
     - path: github.com/google/docsy
       disable: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.14.4-dev",
+  "version": "0.15.0-rc",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",
@@ -53,7 +53,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.24",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.155.3",
+    "hugo-extended": "0.157.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
- Upgrades to Docsy 0.15.0 release candidate
- Upgrades Hugo to required version

No unexpected generated site diffs:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'target="_blank"|href="/site/"|_hu_|contribution-guidelines') | grep ^diff | grep -Ev '\.jpg|\.css'
diff --git a/fa/index.html b/fa/index.html
diff --git a/index.html b/index.html
diff --git a/index.xml b/index.xml
diff --git a/no/index.html b/no/index.html
diff --git a/site/index.html b/site/index.html
```