### PR TITLE
Use `docsy/theme` from docsy 0.15.1-dev+20260530

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260527175607-e20fbd8fc5bf // indirect
+require github.com/google/docsy/theme v0.0.0-20260530181410-94f94145fe15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy/theme v0.0.0-20260527175607-e20fbd8fc5bf h1:aCSucoC+nE0Utovh230EHeXZNMgm0RkxfUaBKftvVSA=
-github.com/google/docsy/theme v0.0.0-20260527175607-e20fbd8fc5bf/go.mod h1:CGCFFJjc3PAYexPDsQqTbB3/lWnncwlwKLnSQkDaaF0=
+github.com/google/docsy/theme v0.0.0-20260530181410-94f94145fe15 h1:ZvwTrXGvb54wT1ajJnnFcepHZnW9R3sypzhAIlGfFps=
+github.com/google/docsy/theme v0.0.0-20260530181410-94f94145fe15/go.mod h1:CGCFFJjc3PAYexPDsQqTbB3/lWnncwlwKLnSQkDaaF0=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
- Contributes to https://github.com/google/docsy/issues/2617
- Updates docsy to 20260530 version