### PR TITLE
Upgrade to Hugo 0.163.1; Docsy theme @ main

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # THIS IS A TEST CONFIG ONLY!
 # FOR THE CONFIGURATION OF YOUR SITE USE hugo.yaml.
 #
-# As of Docsy 0.7.0, Hugo 0.110.0 or later must be used.
+# As of Docsy 0.16, Hugo 0.158.0 or later must be used.
 #
 # The sole purpose of this config file is to detect Hugo-module builds that use
 # an older version of Hugo.
@@ -12,4 +12,4 @@
 module:
   hugoVersion:
     extended: true
-    min: 0.110.0
+    min: 0.158.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260611213000-5c5733de6062 // indirect
+require github.com/google/docsy/theme v0.0.0-20260612162003-f22a352d4262 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy/theme v0.0.0-20260611213000-5c5733de6062 h1:Wm1KR34lrCA0DLlTfVaVaSNl9IoCFd8Dw7vKiH+5Zqc=
-github.com/google/docsy/theme v0.0.0-20260611213000-5c5733de6062/go.mod h1:CGCFFJjc3PAYexPDsQqTbB3/lWnncwlwKLnSQkDaaF0=
+github.com/google/docsy/theme v0.0.0-20260612162003-f22a352d4262 h1:DGXSMc4p24g6M1S4cQ43pRdHfUGdlMRjlraSijTABcw=
+github.com/google/docsy/theme v0.0.0-20260612162003-f22a352d4262/go.mod h1:CGCFFJjc3PAYexPDsQqTbB3/lWnncwlwKLnSQkDaaF0=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -50,8 +50,6 @@ permalinks:
 # Image processing configuration.
 imaging:
   resampleFilter: CatmullRom
-  quality: 75
-  anchor: smart
 
 # Language configuration
 languages:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.158.0",
+    "hugo-extended": "0.163.1",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
- Pins `hugo-extended` to 0.163.1 and updates the Docsy theme module to main (f22a352d, post Hugo-0.163.1  google/docsy#2649).upgrade 
- Streamlines the imaging config per the Hugo 0.163.0 deprecation of global `imaging.quality`: quality 75 and anchor smart match Hugo's defaults, so only the genuine override (`resampleFilter: CatmullRom`) is kept.
- Bumps the old-Hugo guard `config.yaml` min to the current theme floor (0.158.0) so pre-0.110 Hugo users get pointed at the right target version.
- Supersedes #461 (dependabot 0.163.0 bump; auto-closes on merge).

Verification: full test suite green, including the no-deprecations guard (red on `imaging.quality` before the config fix, green after) and the seeded-deprecation canary.
