### PR TITLE
Adopt latest Docsy theme with Hugo 0.163.2

### DIFF
--- a/docsy.work
+++ b/docsy.work
@@ -1,5 +1,5 @@
 go 1.19
 
 use .
-use ../docsy/   // Local docsy clone resides in sibling folder to this project
+use ../docsy/theme/   // Local docsy clone resides in sibling folder to this project
 // use ./themes/docsy/           // Local docsy clone resides in themes folder

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260614124843-f516706840c3 // indirect
+require github.com/google/docsy/theme v0.0.0-20260616181543-6fdfd21b0350 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy/theme v0.0.0-20260614124843-f516706840c3 h1:5iDfW1iwC8gZ3caayHWOyukUG4C7MLb1aL1l+vBP2yc=
-github.com/google/docsy/theme v0.0.0-20260614124843-f516706840c3/go.mod h1:CGCFFJjc3PAYexPDsQqTbB3/lWnncwlwKLnSQkDaaF0=
+github.com/google/docsy/theme v0.0.0-20260616181543-6fdfd21b0350 h1:YImQFnOmgF/CRRvefjR0d86cQ349yhzRRBtSZmho4Jk=
+github.com/google/docsy/theme v0.0.0-20260616181543-6fdfd21b0350/go.mod h1:CGCFFJjc3PAYexPDsQqTbB3/lWnncwlwKLnSQkDaaF0=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.163.1",
+    "hugo-extended": "0.163.2",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },

--- a/tests/favicons.test.mjs
+++ b/tests/favicons.test.mjs
@@ -21,7 +21,7 @@ test('the home page links the favicons supplied in static/', (t) => {
   const h = head(home);
   assert.match(
     h,
-    /<link rel="icon" href="\/favicon\.ico" sizes="16x16 32x32 48x48" \/>/,
+    /<link rel="icon" href="\/favicon\.ico" \/>/,
     'links favicon.ico',
   );
   assert.match(


### PR DESCRIPTION
- Adopts the latest Docsy theme from `google/docsy` main, picking up the Hugo 0.163.2 upgrade ([google/docsy#2658](https://github.com/google/docsy/pull/2658)) and the sizeless favicon links.
- Hugo build:
  - Bumps `hugo-extended` from 0.163.1 to 0.163.2 to match the theme's build.
- Docsy theme module:
  - Pins `github.com/google/docsy/theme` to `6fdfd21b` (google/docsy main).
  - Updates the favicon test to expect `<link rel="icon" href="/favicon.ico" />` without `sizes`, matching the theme's current output.
  - Fixes the local workspace path in `docsy.work` to `../docsy/theme/`, reflecting the theme's move into a `theme/` subdirectory.
- Verifies all site tests pass (6/6) in module mode and local mode, with no Hugo deprecation notices in the build log.
