### PR TITLE
Adopt renamed link-cache package (was lychee-cache)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.163.3",
-    "lychee-cache": "github:chalin/lychee-cache#semver:^0.1.0",
+    "link-cache": "github:chalin/link-cache#semver:^0.2.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
- Repoints the link-check devDep to its renamed home, [chalin/link-cache](https://github.com/chalin/link-cache) (v0.2.0); the old `chalin/lychee-cache` URL only worked via GitHub's repo redirect. Matches google/docsy#2674.
- Bin names are unchanged, so no script changes are needed. The lockfile is gitignored in this repo, hence the one-line diff.
- Validated: `npm install` resolves link-cache@0.2.0; `npm run build` green (en + fa).
