### PR TITLE
Upgrade to Hugo 0.164.0 and update Docsy to main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260630233711-56c5ab12b3fb // indirect
+require github.com/google/docsy/theme v0.0.0-20260716222252-7c9a0608fe4b // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260716222252-7c9a0608fe4b // indirect
+require github.com/google/docsy/theme v0.0.0-20260717003447-4e954dc1bc41 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.0.0-20260716222252-7c9a0608fe4b h1:2c/TwhYfrK3qryrZv7OEyMCRobzBUvMmkpb7MC/tByI=
-github.com/google/docsy/theme v0.0.0-20260716222252-7c9a0608fe4b/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.0.0-20260717003447-4e954dc1bc41 h1:IO7YRKQFjn2KJEsSj37vSi5G0WyXWy3qQ/fcNaLiVjI=
+github.com/google/docsy/theme v0.0.0-20260717003447-4e954dc1bc41/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.0.0-20260630233711-56c5ab12b3fb h1:1uMDFJj1NZUcxkWaleRcU2+3xWgFlXC4P/f0hwZTCdA=
-github.com/google/docsy/theme v0.0.0-20260630233711-56c5ab12b3fb/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.0.0-20260716222252-7c9a0608fe4b h1:2c/TwhYfrK3qryrZv7OEyMCRobzBUvMmkpb7MC/tByI=
+github.com/google/docsy/theme v0.0.0-20260716222252-7c9a0608fe4b/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.163.3",
+    "hugo-extended": "0.164.0",
     "link-cache": "github:chalin/link-cache#semver:^0.2.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"


### PR DESCRIPTION
- Hugo build:
  - Bumps `hugo-extended` from 0.163.3 to **0.164.0**, matching the theme project's build (google/docsy#2679).
  - 0.164.0 requires no migration here: the site builds with zero deprecation notices (guarded by the no-deprecations test) and all 6 tests pass.
- Docsy theme module:
  - Pins `github.com/google/docsy/theme` to `4e954dc1` (google/docsy main as of 2026-07-17, which includes the theme project's own Hugo 0.164.0 build bump, google/docsy#2679); no rendered-output changes from the theme update range.
- Supersedes #475.
- **Preview(s)**:
  - [Home page](https://deploy-preview-477--goldydocs.netlify.app/)
