### PR TITLE
Raise the minimum Hugo version to 0.160.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # THIS IS A TEST CONFIG ONLY!
 # FOR THE CONFIGURATION OF YOUR SITE USE hugo.yaml.
 #
-# As of Docsy 0.16, Hugo 0.158.0 or later must be used.
+# As of Docsy 0.16, Hugo 0.160.1 or later must be used.
 #
 # The sole purpose of this config file is to detect Hugo-module builds that use
 # an older version of Hugo.
@@ -12,4 +12,4 @@
 module:
   hugoVersion:
     extended: true
-    min: 0.158.0
+    min: 0.160.1

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260717003447-4e954dc1bc41 // indirect
+require github.com/google/docsy/theme v0.0.0-20260717130523-6d9367e214fd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.0.0-20260717003447-4e954dc1bc41 h1:IO7YRKQFjn2KJEsSj37vSi5G0WyXWy3qQ/fcNaLiVjI=
-github.com/google/docsy/theme v0.0.0-20260717003447-4e954dc1bc41/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.0.0-20260717130523-6d9367e214fd h1:IPzbNEf+YSj64F/5OQJcuI6wYFdltdGUpTlm+2+TD8g=
+github.com/google/docsy/theme v0.0.0-20260717130523-6d9367e214fd/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -245,7 +245,7 @@ module:
   # workspace: docsy.work
   hugoVersion:
     extended: true
-    min: 0.158.0
+    min: 0.160.1
   imports:
     - path: github.com/google/docsy/theme
       disable: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.15.1-dev+001-over-main-01c827ea",
+  "version": "0.15.1-dev+002-over-main-6d9367e2",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",


### PR DESCRIPTION
- Aligns the site's declared minimum Hugo version (`hugo.yaml` and the early-detection `config.yaml`) with what Docsy main already requires in practice: the npm-dep install flow (google/docsy#2670) silently fails before Hugo 0.159.0, and 0.160.1 excludes the 0.159.2–0.160.0 regressions.
- Matches the theme-floor raise from google/docsy#2677.