### PR TITLE
Run the link-check bin directly, not via npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "_build": "npm run _hugo-dev --",
     "_check:format": "npx prettier --check .",
-    "_check:links": "npx lychee-norm-cache",
+    "_check:links": "lychee-norm-cache",
     "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit --allow-empty -m \"Site at $HASH\"",
     "_diff:check": "git diff --name-only --exit-code",
     "_fix:permissions": "chmod -R u+w public/* 2>/dev/null || true",


### PR DESCRIPTION
- Drops `npx` from the `_check:links` script: `npm run` already puts `node_modules/.bin` on the `PATH`, so the bin provided by the `link-cache` devDependency resolves directly.
- Rationale: `npx BIN` silently falls back to the public npm registry when `node_modules` is stale or missing, executing whatever package claims that name there; a bare bin name instead fails loudly (exit 127) with zero registry traffic.
- Verified: the script resolves the local bin; with the devDependency removed from `node_modules`, it exits 127 with no network access.