### PR TITLE
Install link-cache from the npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "autoprefixer": "^10.5.0",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.164.0",
-    "link-cache": "github:chalin/link-cache#semver:^0.2.0",
+    "link-cache": "^0.3.0",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },


### PR DESCRIPTION
- Follow-up to #480: switches the `link-cache` devDependency from the GitHub pin (`github:chalin/link-cache#semver:^0.2.0`) to the package's first npm registry release, published with the registry's strictest settings (trusted publishing, 2FA required, tokens disallowed).
- Registry installs are faster (no git clone) and immutable — a published version's tarball can't change, which matters here since lockfiles are gitignored.
- Verified: `npm install` resolves `link-cache@0.3.0` from the registry, and the `lychee-norm-cache` bin runs from `node_modules/.bin`.