### PR TITLE
Release 0.16.0

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -72,6 +72,7 @@ https://github.com/google/docsy,200,1782766676
 https://github.com/google/docsy-example,200,1782766676
 https://github.com/google/docsy-example/issues,200,1782766676
 https://github.com/google/docsy-example/pulls,200,1782766676
+https://github.com/google/docsy/releases/v0.16.0,200,1785357023
 https://github.com/google/docsy/tree/main/docsy.dev,200,1782766676
 https://github.com/kubeflow/website/blob/master/README.md,200,1782766676
 https://gohugo.io/,200,1782763743

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.0.0-20260717130523-6d9367e214fd // indirect
+require github.com/google/docsy/theme v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.0.0-20260717130523-6d9367e214fd h1:IPzbNEf+YSj64F/5OQJcuI6wYFdltdGUpTlm+2+TD8g=
-github.com/google/docsy/theme v0.0.0-20260717130523-6d9367e214fd/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.16.0 h1:9uV9qEhk7UpJ8KYbSpTPQlq6htH+8hYskedgGZVnNsU=
+github.com/google/docsy/theme v0.16.0/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -41,6 +41,7 @@ outputFormats:
     baseName: _redirects
     isPlainText: true
     mediaType: text/redirects
+    notAlternative: true
     root: true
 
 # Configure how URLs look like per section.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -127,7 +127,7 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.15.1-dev
+  version: 0.16.0
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/google/docsy-example

--- a/lychee.toml
+++ b/lychee.toml
@@ -15,7 +15,6 @@ exclude_path = [
 exclude = [
   '[?&]link-check=no',                              # opt-out query param
   '/index\.xml$',                                   # rel=alternate RSS links
-  '/_redirects$',                                   # rel=alternate Netlify redirects
   '^https?://[^/]+/(categories|tags)/',             # Docsy-generated taxonomy
   '^https?://localhost\b',
   '^https://upload\.wikimedia\.org/',               # bot-wall (400) on automated thumb requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.15.1-dev+002-over-main-6d9367e2",
+  "version": "0.16.0",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "update": "npm run update:packages && npm run update:docsy:mod"
   },
   "devDependencies": {
-    "autoprefixer": "^10.5.0",
+    "autoprefixer": "^10.5.4",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.164.0",
     "link-cache": "^0.3.0",
@@ -67,8 +67,8 @@
     "rtlcss": "^4.3.0"
   },
   "optionalDependencies": {
-    "npm-check-updates": "^22.2.1",
-    "prettier": "^3.8.3"
+    "npm-check-updates": "^23.0.0",
+    "prettier": "^3.9.6"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
- Contributes to google/docsy#2615
- Pins the theme at the nested module tag `theme/v0.16.0` (first release under the monorepo scheme); Hugo floor was raised early by #478
- Upgrade actions from the release post were validated pre-release in this branch's worktree: clean build, `test:site` 6/6, no guide feedback