### PR TITLE
Set site version to 0.16.1-dev

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -128,7 +128,7 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.16.0
+  version: 0.16.1-dev
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/google/docsy-example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.16.0",
+  "version": "0.16.1-dev+001-over-main-9e5d51b7",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",


### PR DESCRIPTION
- Post-0.16.0-release dev stamp via `set:version:example:git-info`, per the [maintainer notes followup step](https://www.docsy.dev/project/about/maintainer-notes/#post-docsy-release-followup) — sibling to [google/docsy#2697](https://github.com/google/docsy/pull/2697); precedent: #456
- Stamp-only this cycle: the dependency updates that #456 bundled already landed with the 0.16.0 release (#483)
